### PR TITLE
Add Reloaded II instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
 - Open up the game properties in Steam and add `WINEDLLOVERRIDES="dsound=n,b" %command%` to the launch options.
 
 <details>
-    <summary>If you want to use Reloaded II mods alongside P3RFix</summary>
-    This applies to both Windows and Steam Deck/Linux
-    To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
-    - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
-    - In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
-    - Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
-    - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
-    - Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)
-    - You should now be able to start the game and see both P3RFix and Reloaded II mods working
+<summary>If you want to use Reloaded II mods alongside P3RFix</summary>
+This applies to both Windows and Steam Deck/Linux
+To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
+
+- Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
+- In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
+- Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
+- You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
+- Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)
+- You should now be able to start the game and see both P3RFix and Reloaded II mods working
+
 </details>
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To make sure P3RFix loads alongside any Reloaded II mods you are using, follow t
 - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
 - In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
 ![asiloader_reloaded](https://github.com/SupDos/P3RFix/assets/6813986/fd843f9a-22b7-4200-8f6d-89ca6af885a7)
-- Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
+- Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content\P3R\Binaries\WinGDK**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
 - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
 - Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)
 - You should now be able to start the game and see both P3RFix and Reloaded II mods working

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
   
 *This applies to both Windows and Steam Deck/Linux*
 
+Note: Reloaded II **might not work** if you use the **Game Pass/MS Store version of P3R** (see [this page](https://gamebanana.com/tuts/17165) if you want help with that) so it's recommended to only follow these steps if you are using the Steam version. 
+
 Before starting, make sure to **delete any P3RFix files** inside of the game's files **if you have already have used this fix** previously (*P3RFix.ini*, *P3RFix.asi*, *dsound.ini* and *dsound.dll*)
 
 To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
@@ -31,7 +33,7 @@ To make sure P3RFix loads alongside any Reloaded II mods you are using, follow t
 - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
 - In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
 ![asiloader_reloaded](https://github.com/SupDos/P3RFix/assets/6813986/fd843f9a-22b7-4200-8f6d-89ca6af885a7)
-- Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content\P3R\Binaries\WinGDK**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
+- Once this is done, open the game's binary folder (e.g. "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
 - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
 - Copy *P3RFix.ini* and *P3RFix.asi* into this folder
 - You should now be able to start the game and see both P3RFix and Reloaded II mods working

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
 
 <details>
 <summary>If you want to use Reloaded II mods alongside P3RFix</summary>
+  
 This applies to both Windows and Steam Deck/Linux
+
 To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
 
 - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
 <details>
 <summary>If you want to use Reloaded II mods alongside P3RFix</summary>
   
-This applies to both Windows and Steam Deck/Linux
+*This applies to both Windows and Steam Deck/Linux*
 
 To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
 
 - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
 - In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
+![asiloader_reloaded](https://github.com/SupDos/P3RFix/assets/6813986/fd843f9a-22b7-4200-8f6d-89ca6af885a7)
 - Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
 - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
 - Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
   
 *This applies to both Windows and Steam Deck/Linux*
 
+Before starting, make sure to **delete any P3RFix files** inside of the game's files **if you have already have used this fix** previously (*P3RFix.ini*, *P3RFix.asi*, *dsound.ini* and *dsound.dll*)
+
 To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
 
 - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
@@ -31,7 +33,7 @@ To make sure P3RFix loads alongside any Reloaded II mods you are using, follow t
 ![asiloader_reloaded](https://github.com/SupDos/P3RFix/assets/6813986/fd843f9a-22b7-4200-8f6d-89ca6af885a7)
 - Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content\P3R\Binaries\WinGDK**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
 - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
-- Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)
+- Copy *P3RFix.ini* and *P3RFix.asi* into this folder
 - You should now be able to start the game and see both P3RFix and Reloaded II mods working
 
 </details>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
 🚩**You do not need to do this if you are using Windows!**
 - Open up the game properties in Steam and add `WINEDLLOVERRIDES="dsound=n,b" %command%` to the launch options.
 
+<details>
+    <summary>If you want to use Reloaded II mods alongside P3RFix</summary>
+    This applies to both Windows and Steam Deck/Linux
+    To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
+    - Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156)
+    - In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*
+    - Once this is done, open the game's binary folder (e.g. "**XboxGames\Persona 3 Reload\Content**" for Xbox/MS Store or "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam)
+    - You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader
+    - Copy *P3RFix.ini* and *P3RFix.asi* into this folder (if you previously had P3RFix.ini and P3RFix.asi next to the game's .exe, you can remove these 2 files)
+    - You should now be able to start the game and see both P3RFix and Reloaded II mods working
+</details>
+
 ## Configuration
 - See **P3RFix.ini** to adjust settings for the fix.
 


### PR DESCRIPTION
Adds instructions to set up Reloaded II alongside P3RFix using Reloaded II's ASI Loader.

Of note I had it written so that P3RFix's .ini and .asi are moved into the *scripts* folder which Reloaded II creates, just to keep the directory a bit cleaner, but can be changed to have them put next to the .exe as usual if that is preferred. (Edit, maybe not? Having them next to the .exe seems to not work for some people https://github.com/Lyall/P3RFix/issues/15#issuecomment-1945278749)

I'm also not sure where exactly the .exe is on Xbox/MS Store as I've only got the game on Steam, so the full path to that is missing.