### PR TITLE
Properly Scale Menu Assets (RenderTexture2D scaling)

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -751,9 +751,21 @@ void GraphicalTweaks()
 
 							if (iRenTexSizeX == 1920 && iRenTexSizeY == 1080) {
 								// Seems to affect pause menu screens, has some minor bugs in transitions
-								float fRenderScale = fScreenPercentage / 100.0f;
-								iRenTexSizeX = iCustomResX * fRenderScale;
-								iRenTexSizeY = iCustomResY * fRenderScale;
+float fRenderScale = fScreenPercentage / 100.0f;
+iRenTexSizeX = iCustomResX * fRenderScale;
+iRenTexSizeY = iCustomResY * fRenderScale;
+
+if (fAspectRatio > fNativeAspect)
+{
+    iRenTexSizeX = fHUDWidth * fRenderScale;
+    iRenTexSizeY = iCustomResY * fRenderScale;
+}
+
+if (fAspectRatio < fNativeAspect)
+{
+    iRenTexSizeX = iCustomResX * fRenderScale;
+    iRenTexSizeY = fHUDHeight * fRenderScale;
+}
 								spdlog::info("Render Texture 2D screen percent: {:f}, {:d}x{:d}", fRenderScale, iCustomResX, iCustomResY);
 							}
 							else if (iRenTexSizeX > iRenTexSizeY) {


### PR DESCRIPTION
The context for this PR is in issue #17. This PR seems to work in my testing, besides some minor visual issues that are not directly caused by RenderTexture2D. A quick example: https://youtu.be/RFTeLMdHlR8
At this point, it may be worth making some further changes, such as more verbose support for `fRenTexResMultiX` within the config file. (Though using fRenTexResMultiX may have bogus results at some point)
This could also use far more testing, as they may be issues that I have yet to see, which are related to how I chose to scale the RenderTexture2Ds.