### PR TITLE
Produce Native Reloaded-II Package in CI

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -6,7 +6,11 @@ on:
       version:
         description: 'Release version number'
         required: true
-        
+
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   build:
     runs-on: windows-latest
@@ -28,20 +32,65 @@ jobs:
         repository: "ThirteenAG/Ultimate-ASI-Loader"
         latest: true
         fileName: "Ultimate-ASI-Loader_x64.zip"
-    - run: unzip Ultimate-ASI-Loader_x64.zip -d .\; echo [GlobalSets]`nDontLoadFromDllMain=0 > .\dsound.ini; C:\msys64\usr\bin\wget.exe -O .\UltimateASILoader_LICENSE.md https://raw.githubusercontent.com/ThirteenAG/Ultimate-ASI-Loader/master/license
-    - run: mkdir .\zip\Gamepass\P3R\Binaries\WinGDK; mkdir .\zip\Steam\P3R\Binaries\Win64
+
+    - name: Prepare Ultimate ASI Loader
+      run: |
+        unzip Ultimate-ASI-Loader_x64.zip -d .\
+        C:\msys64\usr\bin\wget.exe -O .\UltimateASILoader_LICENSE.md https://raw.githubusercontent.com/ThirteenAG/Ultimate-ASI-Loader/master/license
+        
+    - name: Create Directory Structure
+      run: |
+        mkdir .\zip\Gamepass\P3R\Binaries\WinGDK
+        mkdir .\zip\Steam\P3R\Binaries\Win64
+        mkdir .\zip\Reloaded-II
+
     # Xbox
-    - run: cp ${{ github.event.repository.name }}.asi .\zip\Gamepass\P3R\Binaries\WinGDK\; cp ${{ github.event.repository.name }}.ini .\zip\Gamepass\P3R\Binaries\WinGDK\
-    - run: cp dsound.ini .\zip\Gamepass\P3R\Binaries\WinGDK\; cp dinput8.dll .\zip\Gamepass\P3R\Binaries\WinGDK\dsound.dll; cp UltimateASILoader_LICENSE.md .\zip\Gamepass\P3R\Binaries\WinGDK\; New-Item -Path ".\zip\Gamepass\EXTRACT_TO_GAME_FOLDER" -ItemType File
-    - run: cd .\zip\Gamepass; 7z a -r -tzip ..\..\${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Xbox.zip .\*
+    - name: Prepare Xbox Files
+      run: |
+        cp ${{ github.event.repository.name }}.asi .\zip\Gamepass\P3R\Binaries\WinGDK\
+        cp ${{ github.event.repository.name }}.ini .\zip\Gamepass\P3R\Binaries\WinGDK\
+        cp dinput8.dll .\zip\Gamepass\P3R\Binaries\WinGDK\dsound.dll
+        cp UltimateASILoader_LICENSE.md .\zip\Gamepass\P3R\Binaries\WinGDK\
+        New-Item -Path ".\zip\Gamepass\EXTRACT_TO_GAME_FOLDER" -ItemType File
+        
+    - name: Create Xbox Zip
+      run: |
+        cd .\zip\Gamepass
+        7z a -r -tzip ..\..\${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Xbox.zip .\*
+
     # Steam
-    - run: cp ${{ github.event.repository.name }}.asi .\zip\Steam\P3R\Binaries\Win64\; cp ${{ github.event.repository.name }}.ini .\zip\Steam\P3R\Binaries\Win64\
-    - run: cp dsound.ini .\zip\Steam\P3R\Binaries\Win64\; cp dinput8.dll .\zip\Steam\P3R\Binaries\Win64\dsound.dll; cp UltimateASILoader_LICENSE.md .\zip\Steam\P3R\Binaries\Win64\; New-Item -Path ".\zip\Steam\EXTRACT_TO_GAME_FOLDER" -ItemType File
-    - run: cd .\zip\Steam; 7z a -r -tzip ..\..\${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Steam.zip .\*
-    
+    - name: Prepare Steam Files
+      run: |
+        cp ${{ github.event.repository.name }}.asi .\zip\Steam\P3R\Binaries\Win64\
+        cp ${{ github.event.repository.name }}.ini .\zip\Steam\P3R\Binaries\Win64\
+        cp dinput8.dll .\zip\Steam\P3R\Binaries\Win64\dsound.dll
+        cp UltimateASILoader_LICENSE.md .\zip\Steam\P3R\Binaries\Win64\
+        New-Item -Path ".\zip\Steam\EXTRACT_TO_GAME_FOLDER" -ItemType File
+        
+    - name: Create Steam Zip
+      run: |
+        cd .\zip\Steam
+        7z a -r -tzip ..\..\${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Steam.zip .\*
+
+    # Reloaded-II
+    - name: Prepare Reloaded-II Files
+      run: |
+        cp ${{ github.event.repository.name }}.asi .\zip\Reloaded-II\
+        cp ${{ github.event.repository.name }}.ini .\zip\Reloaded-II\
+        cp assets\r2-package\ModConfig.json .\zip\Reloaded-II\
+
+        $pathToJson = ".\zip\Reloaded-II\ModConfig.json"
+        $version = "${{ github.event.inputs.version }}".TrimStart('v') # Remove 'v' prefix from version
+        (Get-Content $pathToJson -Raw) -replace '<REPLACED_VERSION_IN_CI>', $version | Set-Content $pathToJson
+
+    - name: Create Reloaded-II Zip
+      run: |
+        cd .\zip\Reloaded-II
+        7z a -r -tzip ..\..\${{ github.event.repository.name }}_Reloaded-II.zip .\*
+          
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Steam.zip, ${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Xbox.zip"
+        artifacts: "${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Steam.zip, ${{ github.event.repository.name }}_${{ github.event.inputs.version }}_Xbox.zip, ${{ github.event.repository.name }}_Reloaded-II.zip"
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.event.inputs.version }}
         name: "${{ github.event.inputs.version }}"

--- a/README.md
+++ b/README.md
@@ -22,22 +22,20 @@ This is a fix that adds custom resolutions, ultrawide support and more to Person
 - Open up the game properties in Steam and add `WINEDLLOVERRIDES="dsound=n,b" %command%` to the launch options.
 
 <details>
-<summary>If you want to use Reloaded II mods alongside P3RFix</summary>
+<summary>Installing P3RFix as a Reloaded II Mod</summary>
   
 *This applies to both Windows and Steam Deck/Linux*
-
-Note: Reloaded II **might not work** if you use the **Game Pass/MS Store version of P3R** (see [this page](https://gamebanana.com/tuts/17165) if you want help with that) so it's recommended to only follow these steps if you are using the Steam version. 
 
 Before starting, make sure to **delete any P3RFix files** inside of the game's files **if you have already have used this fix** previously (*P3RFix.ini*, *P3RFix.asi*, *dsound.ini* and *dsound.dll*)
 
 To make sure P3RFix loads alongside any Reloaded II mods you are using, follow these steps:
 
-- Set up Reloaded II and enable any mods you want as per the instructions on [GameBanana](https://gamebanana.com/tuts/17156).
-- In Reloaded II go to *Edit Application*, *Advanced Tools & Options*, *Deploy ASI Loader*.
-![asiloader_reloaded](https://github.com/Lyall/P3RFix/assets/695941/79ad9641-ee10-48b0-a04f-ecc72908ad83)
-- Once this is done, open the game's binary folder (e.g. "**steamapps\common\P3R\P3R\Binaries\Win64**" for Steam).
-- You should see a *scripts* folder which Reloaded II created when deploying the ASI Loader.
-- Move *P3RFix.asi* into this folder.
+- Install the P3RFix Reloaded-II package.
+    - ![pulse-browser_9bf87yUHiU](https://github.com/Lyall/P3RFix/assets/6697380/9a0b6bdf-ebda-45e2-a292-7858107c3435)
+
+- Drag and drop `P3RFix_Reloaded-II.zip` onto the Reloaded-II window. (Alternatively: [Manual Install](https://reloaded-project.github.io/Reloaded-II/QuickStart/))
+
+- Enable it in your `Reloaded-II` mod list.
 - You should now be able to start the game and see both P3RFix and Reloaded II mods working.
 
 </details>

--- a/assets/r2-package/ModConfig.json
+++ b/assets/r2-package/ModConfig.json
@@ -1,0 +1,33 @@
+{
+  "ModId": "p3rpc.p3rfix",
+  "ModName": "P3RFix",
+  "ModAuthor": "Lyatt",
+  "ModVersion": "<REPLACED_VERSION_IN_CI>",
+  "ModDescription": "An \u0027Essentials\u0027 mod for P3R",
+  "ModDll": "",
+  "ModIcon": "",
+  "ModR2RManagedDll32": "",
+  "ModR2RManagedDll64": "",
+  "ModNativeDll32": "",
+  "ModNativeDll64": "P3RFix.asi",
+  "Tags": [],
+  "CanUnload": null,
+  "HasExports": null,
+  "IsLibrary": false,
+  "ReleaseMetadataFileName": "p3rpc.p3rfix.ReleaseMetadata.json",
+  "PluginData": {
+    "GitHubRelease": {
+      "UserName": "Lyall",
+      "RepositoryName": "P3RFix",
+      "UseReleaseTag": true,
+      "AssetFileName": "P3RFix_Reloaded-II.zip"
+    }
+  },
+  "IsUniversalMod": false,
+  "ModDependencies": [],
+  "OptionalDependencies": [],
+  "SupportedAppId": [
+    "p3r.exe"
+  ],
+  "ProjectUrl": "https://github.com/Lyall/P3RFix"
+}

--- a/assets/r2-package/ModConfig.json
+++ b/assets/r2-package/ModConfig.json
@@ -3,7 +3,7 @@
   "ModName": "P3RFix",
   "ModAuthor": "Lyatt",
   "ModVersion": "<REPLACED_VERSION_IN_CI>",
-  "ModDescription": "An \u0027Essentials\u0027 mod for P3R",
+  "ModDescription": "An \u0027Essentials\u0027 mod for P3R. Edit `P3RFix.ini` in Mod Folder to configure settings.",
   "ModDll": "",
   "ModIcon": "",
   "ModR2RManagedDll32": "",


### PR DESCRIPTION
This PR produces a Reloaded-II native package as part of the CI workflow (and makes some other minor changes)

![pulse-browser_9bf87yUHiU](https://github.com/Lyall/P3RFix/assets/6697380/9a0b6bdf-ebda-45e2-a292-7858107c3435)

![image](https://github.com/Lyall/P3RFix/assets/6697380/e4bfe3fe-77e4-4f33-accc-aeb2e3834ce9)

The CI version is automatically injected into the Reloaded-II `ModConfig.json`, and automated updates should also work.
(Using the legacy update system)

-------------------

Ingame Screenshot (MS Store Version):

![image](https://github.com/Lyall/P3RFix/assets/6697380/fd6c873a-d000-4ee6-a1c4-8b907d35af5d)

Nothing special was done to get here. 
Add game in Reloaded, add P3RFix, add `Is It Working`, boot and screenshot.

Now that I have the ability to use a few internal Windows COM interfaces to boot a process in the UWP Centennial sandbox, and use that process as a payload to decrypt the game files, things in R2 just work out of the box.

-------------------

Other Changes:
- I cleaned up the CI for you, should hopefully be easier to read/manage.
- Removed `nDontLoadFromDllMain=0`. Unless you have a very good reason, letting mods load from DllMain under Windows Loader Lock is not a good idea. (This mod doesn't need it anyway)
- Config and Log are written inside the DLL directory. So if `P3RFix.asi` is moved to outside of the game folder, it'll write in that same folder.
- Updated install instructions in Readme.
- Uses automated updates inside Reloaded-II.

That's all, happy gaming!