### PR TITLE
Better mouse support in free/dungeon cam

### DIFF
--- a/P3RFix.ini
+++ b/P3RFix.ini
@@ -63,3 +63,12 @@ Multiplier = 1
 ; Note that this will override UncapMenuFPS.
 AdjustFPSCap = false
 Framerate = 120
+
+[Mouse Fix]
+; Relatively untested fix for the stupid smooth camera when using mouse controls. Disable this if you run into any weird camera movement
+; Makes mouse camera movement act more like a normal 3rd person game (e.g. P5R)
+; You likely aren't making any FPS trickshots with it but it's better than it was
+Enabled = false
+; Dynamically disables the camera fix when using a controller
+; This should work even if you switch back and forth (for some reason)
+IgnoreGamepad = true

--- a/P3RFix.ini
+++ b/P3RFix.ini
@@ -69,6 +69,13 @@ Framerate = 120
 ; Makes mouse camera movement act more like a normal 3rd person game (e.g. P5R)
 ; You likely aren't making any FPS trickshots with it but it's better than it was
 Enabled = false
-; Dynamically disables the camera fix when using a controller
+; Dynamically disables the camera fix when using a controller (or some input device that isn't a mouse)
 ; This should work even if you switch back and forth (for some reason)
+; Any detected mouse input will always override the gamepad, however. Unlike the original game where gamepad camera movement overrides mouse camera movement
+; Disabling this will likely break gamepad support entirely
 IgnoreGamepad = true
+; Mouse X and Y (Yaw and Pitch) movements will be multiplied by these respectively
+; Basically replaces the mouse sensitivity option because that's broken now
+; Negative values can be used to invert the mouse, if you want that
+MouseMultiplierX = 1.0
+MouseMultiplierY = 1.0


### PR DESCRIPTION
Adds patches to the camera and input system to make the camera behave more like P5R
Camera speed is directly controlled by the mouse movement amount per frame, instead of accelerating and decelerating slowly Mouse input for free cameras is taken directly from Windows Raw Input. In-game mouse sensitivity will no longer work so there's a configurable mouse input multiplier. In-game camera speed will still work though (but still applies to both mouse and gamepad).
Controller inputs are detected and the fix is disabled for them.
The entire patch set likely needs more extensive testing, so it's been put in the experimental section
All of this *should* only apply to free cameras (i.e. inside Tartarus, the dorm lobby, etc.) and not cameras fixed in place (or battle cameras)

Fixes #31 